### PR TITLE
Add default circle configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,185 @@
+version: 2
+jobs:
+
+  # If you want to deploy your container to Docker Hub, you must
+  #  1. define the CONTAINER_NAME environment variable for the project
+  #     If not defined, will use the repo that is being built from.
+  #  2. Define the DOCKER_TAG if you have preference. If not defined, will use
+  #     the commit associated with the build.
+  #  3. define the REPO_NAME with the juypter notebook you want to build. If not
+  #     defined, will use https://www.github.com/{CONTAINER_NAME}
+  #  4. Also define DOCKER_USER and DOCKER_PASS (for deploy, if wanted)
+  setup:
+    environment:
+      - TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    docker:
+      - image: docker:18.01.0-ce-git
+      - image: circleci/python:3.6.1
+    steps:
+      - run:
+          name: Test if the user has defined the repository name 
+          command: apk add --no-cache pigz python3
+
+  build:
+    environment:
+      - TZ: "/usr/share/zoneinfo/America/Los_Angeles"
+    docker:
+      - image: docker:18.01.0-ce-git
+    working_directory: /tmp/src
+    steps:
+      - run:
+          name: Install parallel gzip and python3
+          command: apk add --no-cache pigz python3
+      - restore_cache:
+          keys:
+            - docker-v1-{{ .Branch }}
+          paths:
+            - /tmp/cache/container.tar.gz
+      - restore_cache:
+          key: dependency-cache-repo2docker
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Load Docker image layer cache
+          no_output_timeout: 30m
+          command: |
+            docker info
+            set +o pipefail
+            if [ -f /tmp/cache/container.tar.gz ]; then
+              pigz -d --stdout /tmp/cache/container.tar.gz | docker load
+            fi
+            docker images
+      - run:
+          name: Run jupyter-repo2docker to generate Docker Container
+          no_output_timeout: 60m
+          command: |
+            echo "0. Installing dependencies..."
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install jupyter-repo2docker
+            export VERSION=$(python3 -c "import repo2docker; print(repo2docker.__version__)")
+            echo "repo2docker version: ${VERSION}"
+            echo "1. Preparing building environment"
+            echo "Working directory is ${PWD}"
+            # If not set, define DOCKER_TAG
+            if [ ! -n "${DOCKER_TAG:-}" ]
+                then
+                    DOCKER_TAG=$(echo "${CIRCLE_SHA1}" | cut -c1-10)
+            fi
+            # If not set, define CONTAINER_NAME
+            if [ ! -n "${CONTAINER_NAME:-}" ]
+                then
+                    CONTAINER_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+            fi
+            # If not set, use testing repo name
+            if [ ! -n "{REPO_NAME}" ]
+              then
+              ${REPO_NAME}="https://www.github.com/${CONTAINER_NAME}"
+            fi
+            echo "Container name is ${CONTAINER_NAME}"
+            echo "Repository name is ${REPO_NAME}"
+            echo "2. Running jupyter-repo2docker..."
+            echo "jupyter-repo2docker --debug --user-name username --user-id 1000 --no-run --image-name ${CONTAINER_NAME}:${DOCKER_TAG} ${REPO_NAME}"
+            jupyter-repo2docker --debug --user-name username --user-id 1000 --no-run --image-name "${CONTAINER_NAME}:${DOCKER_TAG}" "${REPO_NAME}"
+            docker ps
+            docker images
+      - run:
+          name: Docker Save
+          no_output_timeout: 40m
+          command: |
+            # If not set, use commit id as tag
+            if [ ! -n "${DOCKER_TAG:-}" ]
+                then
+                    DOCKER_TAG=$(echo "${CIRCLE_SHA1}" | cut -c1-10)
+            fi
+            # If not set, define CONTAINER_NAME
+            if [ ! -n "${CONTAINER_NAME:-}" ]
+                then
+                    CONTAINER_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+            fi
+            echo "Saving ${CONTAINER_NAME}:${DOCKER_TAG} to container.tar.gz"
+            mkdir -p /tmp/cache
+            docker save ${CONTAINER_NAME}:${DOCKER_TAG} \
+              | pigz -2 -p 3 > /tmp/cache/container.tar.gz
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - cache/container.tar.gz
+            - src
+
+  update_cache:
+    machine:
+      # Ubuntu 14.04 with Docker 17.10.0-ce
+      image: circleci/classic:201711-01
+    working_directory: /tmp/src
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - save_cache:
+         key: docker-v1-{{ .Branch }}
+         paths:
+            - /tmp/cache/container.tar.gz
+
+  deploy:
+    machine:
+      image: circleci/classic:201711-01
+    working_directory: /tmp/src
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - run:
+          name: Load Docker image layer cache
+          no_output_timeout: 30m
+          command: |
+            echo "Working directory is ${PWD}"
+            docker info
+            set +o pipefail
+            if [ -f /tmp/cache/container.tar.gz ]; then
+              sudo apt update && sudo apt -y install pigz
+              pigz -d --stdout /tmp/cache/container.tar.gz | docker load
+              docker images
+            fi
+      - run:
+          name: Deploy to Docker Hub
+          no_output_timeout: 40m
+          command: |
+            echo "Looking for Docker deployment options"
+            if [ ! -n "${DOCKER_TAG:-}" ]
+                then
+                    DOCKER_TAG=$(echo "${CIRCLE_SHA1}" | cut -c1-10)
+            fi
+            # If not set, define CONTAINER_NAME
+            if [[ ! -n "${CONTAINER_NAME:-}" ]]
+                then
+                    CONTAINER_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+            fi
+            echo "Container name set to ${CONTAINER_NAME}:${DOCKER_TAG}"
+            if [[ -n "$DOCKER_PASS" ]]; then
+                  docker login -u $DOCKER_USER -p $DOCKER_PASS
+                  docker push ${CONTAINER_NAME}:${DOCKER_TAG}
+            fi
+workflows:
+  version: 2
+  build_deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+
+      - update_cache:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /docs?\/.*/
+            tags:
+              only: /.*/
+
+      # This is where we upload the container to some final resting spot :)
+      - deploy:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   # If you want to deploy your container to Docker Hub, you must
   #  1. define the CONTAINER_NAME environment variable for the project
-  #     If not defined, will use the repo that is being built from.
+  #     If not defined, will use the repository that is being built from.
   #  2. Define the DOCKER_TAG if you have preference. If not defined, will use
   #     the commit associated with the build.
   #  3. define the REPO_NAME with the juypter notebook you want to build. If not

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ be desired for all users.
 
 ## Request an Example
 
-If you want to get help, or request an example, please [let us know!](https://www.github.com/jupyter/continuous-build/issues)
+If you want to get help, or request an example, please [let us know!](https://www.github.com/binder-examples/continuous-build/issues)

--- a/README.md
+++ b/README.md
@@ -9,3 +9,20 @@ a container that serves your notebook for others to use.
 For complete documentation, please see 
 [repo2docker](https://repo2docker.readthedocs.io/en/latest/deploy.html) 
 on ReadTheDocs.
+
+## Examples Provided
+
+A circle configuration will be automatically detected in a hidden folder (`.circleci`)
+that has a config.yml inside. In this repository, we have such a folder, and
+this can be considered the base template for you to work from.
+
+  - [.circleci](.circleci): 
+
+We will be adding other example templates here as they are requested. For example,
+it would be useful to have further testing of the container, or conversion with nbconvert.
+These functions are not provided by default in the configuration above as they may not
+be desired for all users. 
+
+## Request an Example
+
+If you want to get help, or request an example, please [let us know!](https://www.github.com/jupyter/continuous-build/issues)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # continuous-build
-Show how to use continuous integration to test your dependency specifications
+
+This is the continuous build repository, with example configurations (and a basic 
+one set up to run on CircleCI) to show how you can use repo2docker to build
+a container that serves your notebook for others to use.
+
+## Documentation
+
+For complete documentation, please see 
+[repo2docker](https://repo2docker.readthedocs.io/en/latest/deploy.html) 
+on ReadTheDocs.


### PR DESCRIPTION
This pull request will add the basic (one might say a reasonable default) to show an example continuous build using jupyter-repo2docker.  The documentation (README) here is intentionally sparse, and points the user to the jupyter repo2docker base that is the central source of information (we wouldn't want to need to change things twice!). 

 - The [same as before](https://circleci.com/workflow-run/10042199-d8aa-4e41-9764-5535c812fd87) build on Circle is here.
 - The Docker Hub deployment is [still here](https://hub.docker.com/r/vanessa/repo2docker/tags/).
 - The PR with docs for usage is underway [here](https://github.com/jupyter/repo2docker/pull/351)

Woot!