### PR TITLE
Update repo2docker to support Singularity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,9 @@ jobs:
             echo "2. Running jupyter-repo2docker..."
             echo "jupyter-repo2docker --debug --user-name username --user-id 1000 --no-run --image-name ${CONTAINER_NAME}:${DOCKER_TAG} ${REPO_NAME}"
             jupyter-repo2docker --debug --user-name username --user-id 1000 --no-run --image-name "${CONTAINER_NAME}:${DOCKER_TAG}" "${REPO_NAME}"
+            # Issue command to make /home/username read/write for any user, to support Singularity
+            echo "Changing permissions to chmod -R 777 /home/username"
+            docker exec "${CONTAINER_NAME}:${DOCKER_TAG}" chmod -R 777 /home/username
             docker ps
             docker images
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,10 +92,10 @@ jobs:
             echo "2. Running jupyter-repo2docker..."
             echo "jupyter-repo2docker --debug --user-name joyvan --user-id 1000 --no-run --image-name ${CONTAINER_NAME}:${DOCKER_TAG} ${REPO_NAME}"
             jupyter-repo2docker --debug --user-name joyvan --user-id 1000 --no-run --image-name "${CONTAINER_NAME}:${DOCKER_TAG}" "${REPO_NAME}"
-            # Issue command to make /home/username read/write for any user, to support Singularity
-            echo "Changing permissions to chmod -R 777 /home/username"
+            # Issue command to make /home/joyvan read/write for any user, to support Singularity
+            echo "Changing permissions to chmod -R 777 /home/joyvan"
             docker run --name repo2docker -td "${CONTAINER_NAME}:${DOCKER_TAG}"
-            docker exec repo2docker chmod -R 777 /home/username
+            docker exec repo2docker chmod -R 777 /home/joyvan
             docker commit repo2docker "${CONTAINER_NAME}:${DOCKER_TAG}"
             docker ps
             docker images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,9 @@ jobs:
             jupyter-repo2docker --debug --user-name username --user-id 1000 --no-run --image-name "${CONTAINER_NAME}:${DOCKER_TAG}" "${REPO_NAME}"
             # Issue command to make /home/username read/write for any user, to support Singularity
             echo "Changing permissions to chmod -R 777 /home/username"
-            docker exec "${CONTAINER_NAME}:${DOCKER_TAG}" chmod -R 777 /home/username
+            docker run --name repo2docker -td "${CONTAINER_NAME}:${DOCKER_TAG}"
+            docker exec repo2docker chmod -R 777 /home/username
+            docker commit repo2docker "${CONTAINER_NAME}:${DOCKER_TAG}"
             docker ps
             docker images
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints


### PR DESCRIPTION
heyo @betatim et al! This is a simple tweak to the default that I think might be ok / appropriate to allow for a repo2docker build to be easily usable with Docker and Singularity containers. For details, see #6. Basically, we need to have the `/home/username` folder be read/writable for all, because when we convert to a Singularity container, without this the notebooks provided by the container will be read only (even with some tweaking and hacks that I figured out to do at runtime to get the python environment working.) To demonstrate the example, here is the walk through of pulling a container with this fix and using with Singularity. Note that I did this on a shared cluster resource (where I don't have docker or sudo).

## Step 1. Pull Docker container to Singularity

```bash
$ echo $SINGULARITY_CACHEDIR
/scratch/users/vsochat/.singularity
[vsochat@sh-ln01 login! /scratch/users/vsochat/share]$ singularity pull docker://vanessa/repo2docker:5a3204ff58
WARNING: pull for Docker Hub is not guaranteed to produce the
WARNING: same image on repeated pull. Use Singularity Registry
WARNING: (shub://) to pull exactly equivalent images.
Docker image path: index.docker.io/vanessa/repo2docker:5a3204ff58
Cache folder set to /scratch/users/vsochat/.singularity/docker
[13/13] |===================================| 100.0% 
Importing: base Singularity environment
Exploding layer: sha256:4ccdce43d1e00fd03ac5438d39e731c16db3dfcf03c68390884b8e8c814221ca.tar.gz
Exploding layer: sha256:c95f13c88d926e6181e0594f76953a14ab80ce002fc6dbc968084a7e18aaafe9.tar.gz
Exploding layer: sha256:82656eee95ad054e0aa75486e7c55b7666c26abbd9bf19373dd349f6e172ce9d.tar.gz
Exploding layer: sha256:78ff727be57a68299558bb40b737669ca5cb9a8db948411d852ec809c14e7a1f.tar.gz
Exploding layer: sha256:448bb314afa553bfb1578121328bbe92d2b5ca0f411967e7a0a200f672ade92f.tar.gz
Exploding layer: sha256:9d5385822d13da4858fc337a2977cb55db7590f4cb898a1c02086e23fee86ce5.tar.gz
Exploding layer: sha256:e8f408ef01287ccbc19922997eed4c744d6b5d1bbc39933f6beda364cc076077.tar.gz
Exploding layer: sha256:63314e962953b7c89dcc6835b4041ecdfc4e9cf954d3d13ce1684897a3ac9da0.tar.gz
Exploding layer: sha256:889bb04638d1859160b996be0b4306a37dc3178958822c7e4185436e47c2ab7b.tar.gz
Exploding layer: sha256:10f98bbddcd0ad2609560add552417678b2aa519cb380766a593371e8070e327.tar.gz
Exploding layer: sha256:de8836d22d768c3e86e65d90a2e00acb288ce50433456c8095c4d13a3e32cf6e.tar.gz
Exploding layer: sha256:30dba8f44db0fd1aa5a251c4158e6ce4ddcdecfbabbb0fdba325de2e8c6ac604.tar.gz
Exploding layer: sha256:e84e3c4959b034a2cd9601a809e34d24556431c8cc86890871efb05192897c85.tar.gz
Exploding layer: sha256:dc6703ca57fbebb41223a39c56878c18dcb851b19000135244c9b6f6323ab39c.tar.gz
Exploding layer: sha256:cd38d573ab49e9a1d7a4eae7db76c92cff9e538bc621114909d2adfc5b952f42.tar.gz
Exploding layer: sha256:0ce49a89ec0ed4446d5ec6f297a734421a2f19cbc1cd8d4a5d26f6990b74501b.tar.gz
Exploding layer: sha256:92679ae5b0edc86eec4266d2306e17f1df3831f1da44a6aefd8c94b63f468f84.tar.gz
Exploding layer: sha256:7edc8299941e6e11f1649b6d6f553b8603070c3d98fd21bdf4f7bd39037e063a.tar.gz
Exploding layer: sha256:1ad5959e8ec8a0b29f9b3c77121d476dea86c1a8d7540136a16ee63bab8b40c5.tar.gz
Exploding layer: sha256:3e9b88f796d006899458aea49d55bbb69e22a24ecb5ea06101b779de2260962c.tar.gz
Exploding layer: sha256:5fd23e9cb6f61c78a7f4a511e89635e8bcd55f57b246f266ca9377692d862ae3.tar.gz
Exploding layer: sha256:e458d018a7cac4f95ed8ee2a3571e1735d872e2e9fa72bd1c51dfd8227144a1a.tar.gz
WARNING: Building container as an unprivileged user. If you run this container as root
WARNING: it may be missing some functionality.
Building Singularity image...
Singularity container built: /scratch/users/vsochat/.singularity/repo2docker-5a3204ff58.simg
Cleaning up...
Done. Container is at: /scratch/users/vsochat/.singularity/repo2docker-5a3204ff58.simg
```
Just for easier use, move to `$PWD`

```bash
mv /scratch/users/vsochat/.singularity/repo2docker-5a3204ff58.simg $PWD
```

## Step 2. Run It

Run as is, setting --pwd in container to be where I know the notebooks are (so I see them in the browser!) Note that I use sdev first to get an interactive node or my group will hate me for running stuff on the login node :p  The one bind I'm doing is to ensure that my local python modules, if I have any in .local, are available in the container.

```bash
sdev
module load singularity

# come up with a random port and hope it's open, lol
PORT=55587

# This is the container I pulled, it's just a file
CONTAINER=repo2docker-5a3204ff58.simg

# Run it!
singularity exec  ${CONTAINER} jupyter notebook --no-browser --port=$PORT --ip 0.0.0.0
```
```bash
[I 08:37:20.998 NotebookApp] Writing notebook server cookie secret to /tmp/jupyter/notebook_cookie_secret
[I 08:37:21.616 NotebookApp] JupyterLab alpha preview extension loaded from /srv/venv/lib/python3.6/site-packages/jupyterlab
[I 08:37:21.616 NotebookApp] JupyterLab application directory is /srv/venv/share/jupyter/lab
[I 08:37:21.625 NotebookApp] nteract extension loaded from /srv/venv/lib/python3.6/site-packages/nteract_on_jupyter
[I 08:37:21.630 NotebookApp] Serving notebooks from local directory: /scratch/users/vsochat/share
[I 08:37:21.630 NotebookApp] 0 active kernels
[I 08:37:21.630 NotebookApp] The Jupyter Notebook is running at:
[I 08:37:21.630 NotebookApp] http://0.0.0.0:55587/?token=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
[I 08:37:21.630 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
[C 08:37:21.631 NotebookApp] 
    
    Copy/paste this URL into your browser when you connect for the first time,
    to login with a token:
        http://0.0.0.0:55587/?token=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

## Step 3. Forward port on localhost
On my local machine, now I want to open the notebook in my browser! Note the node I'm on is  `sh-08-37`

```bash
MACHINE=sh-08-37
PORT=55587
ssh -L $PORT:localhost:$PORT sherlock ssh -L $PORT:localhost:$PORT -N "$MACHINE"
```

### Test 1. New Notebook
Per the running command above (not setting the --pwd, but letting it be the scratch folder where I ran it from) I am able to create a new notebook and import a dependency that is installed in the container (pokemon). The container notebook also save successfully to my scratch!

![image](https://user-images.githubusercontent.com/814322/43033905-6cc8449c-8c87-11e8-89b2-8077a3c88723.png)

### Test 2. Provided Notebook
But for most data science we would want to provide the notebook that is in the container for use and edit! I control +C'd the command above, and then restarted setting the --pwd of the container to be where the notebook is. If I changed the permission correctly, this should work ok (note that with the current setup it does not, the permissions don't allow write to the folder).

```bash
singularity exec  --pwd /home/username ${CONTAINER} jupyter notebook --no-browser --port=$PORT --ip 0.0.0.0
```
okay this looks good so far - no errors in the console (there would be if we didn't have write permission) and I am now seeing the repository that the container provides as the entrypoint:

![image](https://user-images.githubusercontent.com/814322/43033936-f2a11968-8c87-11e8-8d5e-74fb9d9aae5b.png)

But can I open, use, and edit the example notebook?

![image](https://user-images.githubusercontent.com/814322/43033946-21898f94-8c88-11e8-991b-abf0e3090f5a.png)

yeaaah dawg, I sure can!!

## Summary
In summary, this is a tweak to change the entire permission of  `/home/username` in the Docker container, the base for the repository that the user is building. It's a trivial change for the Docker container because the running user is sudo anyway, but it's a game changer for Singularity because I can:

 1. use the container as a working environment to make new notebooks in my directory of choice (first example)
 2. use the container to work on the notebooks provided in the container, 

But here is a bit of mystery that I don't quite get (and I'm hoping for your help with - it could be a bad singularity bug). With Singularity, I shouldn't be able to write in a read only container. So when write works, it works because the directory is mounted from the host. When I set --pwd it **should** be the case that I'm setting the --pwd of the container to be something that exists in the container and on my host (and in this case it exists in the container but not on the host) and so I would have expected some error with respect to writing files. But I don't see any error, and in fact, I get a message that the example.ipynb is writing... somewhere!

```bash
[I 08:47:11.618 NotebookApp] Writing notebook-signing key to /home/username/.local/share/jupyter/notebook_secret
[W 08:47:11.619 NotebookApp] Notebook example.ipynb is not trusted
[I 08:47:12.058 NotebookApp] Kernel started: 128e9b5b-f035-44fb-b797-feffdd484fd8
[I 08:47:13.449 NotebookApp] Adapting to protocol v5.1 for kernel 128e9b5b-f035-44fb-b797-feffdd484fd8
[I 08:49:12.316 NotebookApp] Saving file at /example.ipynb
[W 08:49:44.315 NotebookApp] Replacing stale connection: 5b430bbd-711c-4d68-bba2-b4a8208c2861:D905C100530846DF986F7B88B83388FA
[I 08:50:20.320 NotebookApp] Saving file at /example.ipynb
[W 08:54:17.310 NotebookApp] Replacing stale connection: 5b430bbd-711c-4d68-bba2-b4a8208c2861:D905C100530846DF986F7B88B83388FA
[I 08:54:21.430 NotebookApp] Saving file at /example.ipynb
[I 08:56:52.580 NotebookApp] Saving file at /example-two.ipynb
[W 08:59:22.291 NotebookApp] Replacing stale connection: 5b430bbd-711c-4d68-bba2-b4a8208c2861:D905C100530846DF986F7B88B83388FA
```
For the life of me, I can't find where on the host the file is writing to... do you have any ideas of where I might look? I looked already at the various jupyter locations in /tmp, etc., but can't find this example-two.ipynb. Does it have something to do with the notebook not being trusted? To verify it's not changing the image file (this should be impossible, actually) I shelled into a different execution of the container binary:

```bash
[vsochat@sh-08-37 /scratch/users/vsochat]$ singularity shell share/repo2docker-5a3204ff58.simg 
Singularity: Invoking an interactive shell within container...

Singularity repo2docker-5a3204ff58.simg:/scratch/users/vsochat> ls /home/username/
example.ipynb  LICENSE	README.md  requirements.txt  venv
```
Is this an issue for making the change here to let Singularity run the container? I don't think so - it's still an improvement on the current because minimally, as a user I can download the notebook from the web interface to my local machine.  

I do, however, want to get some closure about where the notebooks are being saved, just for a sanity check. I'm noticing that I am notified about the credentials saving to `/home/username`

```bash
[I 08:47:11.618 NotebookApp] Writing notebook-signing key to /home/username/.local/share/jupyter/notebook_secret
```
which I **do** have on the host, but I'm not sure if this is from when I've used it there before.

```bash
[vsochat@sh-08-37 /scratch/users/vsochat]$ ls /home/users/vsochat/.local/share/jupyter/
kernels  nbextensions  nbsignatures.db  notebook_secret
```

The other thing that sticks out is that it doesn't trust the notebooks, so maybe they really aren't saved?

```bash
[W 08:47:11.619 NotebookApp] Notebook example.ipynb is not trusted
```

What I'm hoping **isn't** the case is that the notebook is saving somewhere on the host where it should not / somewhere into the container that should be read only, because this would mean I have write in a Singularity image (this should not happen). Let me know if you have other ideas of where to look (on the host) for the files, and I want to ping @dctrud, @cclerget and @godloved to ask about if there are any other Singularity specific locations I might look in.  For the Singularity team - note that this is a running jupyter notebook on a shared cluster resource, forwarded port to my host, and the directory that is serving with `--pwd` has permissions changed (on the Docker Hub build) to `chmod -R 777` It says it's saving and for the life of me I can't find the files! Once we get to the bottom of this, this will be a really awesome feature for (shared resource) cluster users that want quick build and deploy for various interactive working environments. Thanks everyone!