### PR TITLE
Only deploy on master, not for every PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,14 @@ workflows:
   build_deploy:
     jobs:
       - build:
+          filters:
+            tags:
+              only: /.*/
 
       - update_cache:
+          filters:
+            tags:
+              only: /.*/
           requires:
             - build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,23 +174,15 @@ workflows:
   build_deploy:
     jobs:
       - build:
-          filters:
-            tags:
-              only: /.*/
 
       - update_cache:
           requires:
             - build
-          filters:
-            branches:
-              ignore: /docs?\/.*/
-            tags:
-              only: /.*/
 
       # This is where we upload the container to some final resting spot :)
       - deploy:
           requires:
             - build
           filters:
-            tags:
-              only: /.*/
+            branches:
+              only: master


### PR DESCRIPTION
Only want to push the image to docker hub when we merge a PR into master, not for every single push to a branch for a PR.