### PR TITLE
Second Idea: Addition of Singularity Template

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -48,7 +48,8 @@ This is a base, or default configuration to build.
 
 This configuration is equivalent to the default config.yml, with the additional change in permissions of the
 repo2docker folder to allow for the user to write given export into a Singularity container. If you want your
-container notebooks to be usable on a shared resource, you should choose this configuration.
+container notebooks to be usable on a shared resource, you should choose this configuration. Note that the
+save happens in a temporary location provided by the container, and so you would want to save your notebooks as an export to your local machine, or to another location on your shared resource.
 
 **Variables that must be set in CircleCI Project Settings**
 

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -44,11 +44,12 @@ This is a base, or default configuration to build.
 |`DOCKER_TAG`|A custom tag for the deployed image.|no|the first 10 characters of the commit.|
 
 
-## config.singularity
+## config.singularity.yml
 
 This configuration is equivalent to the default config.yml, with the additional change in permissions of the
 repo2docker folder to allow for the user to write given export into a Singularity container. If you want your
-container notebooks to be usable on a shared resource, you should choose this configuration. Note that the
+container notebooks to be usable on a shared HPC resource (e.g., a supercomputer cluster
+with many users), you should choose this configuration. Note that the
 save happens in a temporary location provided by the container, and so you would want to save your notebooks as an export to your local machine, or to another location on your shared resource.
 
 **Variables that must be set in CircleCI Project Settings**

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,68 @@
+# CircleCI 2.0 Workflow Templates
+
+This folder contains template files for CircleCI workflow configurations. You should
+choose the one that you want to use, and name it to be the file `.circleci/config.yml`
+in your repository. Each is described below, along with a description of environment
+variables that you can define in the CircleCI project settings to customize the build.
+
+## Where do I define the variables?
+For each set of variables, some you can define in the config.yml, in the `environment`
+section for a workflow step, for example, here is setting the variable `TIMEZONE`
+to be defined as `/usr/share/zoneinfo/America/Los_Angeles` available during the
+"setup" step:
+
+```bash
+  setup:
+    environment:
+      - TIMEZONE: "/usr/share/zoneinfo/America/Los_Angeles"
+```
+
+or you can define variables in the [CircleCI project settings](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project). 
+The latter is recommended for sensitive information. 
+
+For all configuration descriptions below, **all variables** from both tables 
+can be set in just the CircleCI project settings, if desired.
+
+# Templates
+
+## config.yml
+
+This is a base, or default configuration to build.
+
+**Variables that must be set in CircleCI Project Settings**
+
+|Variable|Description|Required|Default|
+|---|---|---|---|
+|`DOCKER_USER`|Docker username to deploy to Docker Hub. The build will not deploy without it.|no|unset|
+|`DOCKER_PASS`|Docker password to deploy to Docker Hub. The build will not deploy without it.|no|unset|
+
+**Variables that can be set in config.yml**
+ 
+|Variable|Description|Required|Default|
+|---|---|---|---|
+|`CONTAINER_NAME`|The name of the Docker Hub container to deploy|no|`<ORG>/<REPO>`|
+|`DOCKER_TAG`|A custom tag for the deployed image.|no|the first 10 characters of the commit.|
+
+
+## config.singularity
+
+This configuration is equivalent to the default config.yml, with the additional change in permissions of the
+repo2docker folder to allow for the user to write given export into a Singularity container. If you want your
+container notebooks to be usable on a shared resource, you should choose this configuration.
+
+**Variables that must be set in CircleCI Project Settings**
+
+|Variable|Description|Required|Default|
+|---|---|---|---|
+|`DOCKER_USER`|Docker username to deploy to Docker Hub. The build will not deploy without it.|no|unset|
+|`DOCKER_PASS`|Docker password to deploy to Docker Hub. The build will not deploy without it.|no|unset|
+
+**Variables that can be set in config.yml**
+
+|Variable|Description|Required|Default|
+|---|---|---|---|
+|`CONTAINER_NAME`|The name of the Docker Hub container to deploy|no|`<ORG>/<REPO>`|
+|`DOCKER_TAG`|A custom tag for the deployed image.|no|the first 10 characters of the commit.|
+|`NOTEBOOK_PERMISSION`|The permission to (recursively) give the notebook, to allow write.|no|777|
+|`NOTEBOOK_USERNAME`|The username (to derive the home directory) to build the notebook and virtual environment. (e.g., `/home/joyvan`|no|`joyvan`|
+

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -17,8 +17,9 @@ to be defined as `/usr/share/zoneinfo/America/Los_Angeles` available during the
       - TIMEZONE: "/usr/share/zoneinfo/America/Los_Angeles"
 ```
 
-or you can define variables in the [CircleCI project settings](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project). 
-The latter is recommended for sensitive information. 
+Note that timezone isn't necessary for any build step, but provided here as an example.
+Yr you can define environment variables in the 
+[CircleCI project settings](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project). The latter is recommended for sensitive information. 
 
 For all configuration descriptions below, **all variables** from both tables 
 can be set in just the CircleCI project settings, if desired.
@@ -63,8 +64,8 @@ save happens in a temporary location provided by the container, and so you would
 
 |Variable|Description|Required|Default|
 |---|---|---|---|
-|`CONTAINER_NAME`|The name of the Docker Hub container to deploy|no|`<ORG>/<REPO>`|
+|`IMAGE_NAME`|The name of the Docker Hub container to deploy|no|`<ORG>/<REPO>`|
 |`DOCKER_TAG`|A custom tag for the deployed image.|no|the first 10 characters of the commit.|
-|`NOTEBOOK_PERMISSION`|The permission to (recursively) give the notebook, to allow write.|no|777|
-|`NOTEBOOK_USERNAME`|The username (to derive the home directory) to build the notebook and virtual environment. (e.g., `/home/joyvan`|no|`joyvan`|
+|`REPO2DOCKER_PERMISSION`|The permission to (recursively) give the notebook, to allow write.|no|777|
+|`REPO2DOCKER_USERNAME`|The username (to derive the home directory) to build the notebook and virtual environment. (e.g., `/home/joyvan`|no|`joyvan`|
 

--- a/.circleci/config.singularity.yml
+++ b/.circleci/config.singularity.yml
@@ -16,6 +16,11 @@ jobs:
   #     the variable REPO_NAME as the name of the repository that you
   #     want to build. That can be done in this file under build:environment,
   #     or again online in the CircleCI environment variable settings.
+  #  5. Optionally, define the NOTEBOOK_PERMISSION environment variable to set
+  #     a different permission on the notebook folder (default is 777)
+  #  6. Optionally, set the NOTEBOOK_USERNAME to be where you want the
+  #     repo2docker notebooks and virtual environment to be installed
+  #     (default is joyvan)
   setup:
     environment:
       - TZ: "/usr/share/zoneinfo/America/Los_Angeles"
@@ -89,9 +94,24 @@ jobs:
             else
                 echo "Repository name found defined for build: ${REPO_NAME}"
             fi
+            # If not set, define NOTEBOOK_PERMISSION
+            if [ ! -n "${NOTEBOOK_PERMISSION:-}" ]
+                then
+                    NOTEBOOK_PERMISSION=777;
+            fi
+            # If not set, define NOTEBOOK_USERNAME
+            if [ ! -n "${NOTEBOOK_USERNAME:-}" ]
+                then
+                    NOTEBOOK_USERNAME=joyvan;
+            fi
             echo "2. Running jupyter-repo2docker..."
-            echo "jupyter-repo2docker --debug --user-name jovyan --user-id 1000 --no-run --image-name ${CONTAINER_NAME}:${DOCKER_TAG} ${REPO_NAME}"
-            jupyter-repo2docker --debug --user-name jovyan --user-id 1000 --no-run --image-name "${CONTAINER_NAME}:${DOCKER_TAG}" "${REPO_NAME}"
+            echo "jupyter-repo2docker --debug --user-name ${NOTEBOOK_USERNAME} --user-id 1000 --no-run --image-name ${CONTAINER_NAME}:${DOCKER_TAG} ${REPO_NAME}"
+            jupyter-repo2docker --debug --user-name ${NOTEBOOK_USERNAME} --user-id 1000 --no-run --image-name "${CONTAINER_NAME}:${DOCKER_TAG}" "${REPO_NAME}"
+            # Issue command to make /home/${NOTEBOOK_USERNAME} read/write for any user, to support Singularity
+            echo "Changing permissions to chmod -R ${NOTEBOOK_PERMISSION} /home/${NOTEBOOK_USERNAME}"
+            docker run --name repo2docker -td "${CONTAINER_NAME}:${DOCKER_TAG}"
+            docker exec repo2docker chmod -R ${NOTEBOOK_PERMISSION} "/home/${NOTEBOOK_USERNAME}"
+            docker commit repo2docker "${CONTAINER_NAME}:${DOCKER_TAG}"
             docker ps
             docker images
       - run:
@@ -164,7 +184,6 @@ jobs:
                 then
                     CONTAINER_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
             fi
-            echo "Container name set to ${CONTAINER_NAME}:${DOCKER_TAG}"
             echo "Container name set to ${CONTAINER_NAME}:${DOCKER_TAG}"
             if [[ -n "$DOCKER_PASS" ]]; then
                   docker login -u $DOCKER_USER -p $DOCKER_PASS

--- a/.circleci/config.singularity.yml
+++ b/.circleci/config.singularity.yml
@@ -3,7 +3,7 @@ jobs:
 
   # If you want to deploy your container to Docker Hub, you must
   # define environment variables in the CircleCI web interface for your project
-  #  1. define the CONTAINER_NAME environment variable for the project
+  #  1. define the IMAGE_NAME environment variable for the project
   #     Specifically, this is the name of the Docker Hub <ORG>/<NAME> to push
   #     If not defined, will use the repository that is being built from.
   #     to in the case that you have provided Docker credentials.
@@ -11,15 +11,15 @@ jobs:
   #     If you don't define these in CircleCI settings it won't be pushed.
   #  3. Optionally define the DOCKER_TAG. If not defined, will use
   #     the commit associated with the build.
-  #  4. By default, the build assumes wanting to use the local notebook here.
+  #  4. By default, the build assumes wanting to use the local REPO2DOCKER here.
   #     If you want to build from a **different** Github repository, then define
   #     the variable REPO_NAME as the name of the repository that you
   #     want to build. That can be done in this file under build:environment,
   #     or again online in the CircleCI environment variable settings.
-  #  5. Optionally, define the NOTEBOOK_PERMISSION environment variable to set
-  #     a different permission on the notebook folder (default is 777)
-  #  6. Optionally, set the NOTEBOOK_USERNAME to be where you want the
-  #     repo2docker notebooks and virtual environment to be installed
+  #  5. Optionally, define the REPO2DOCKER_PERMISSION environment variable to set
+  #     a different permission on the REPO2DOCKER folder (default is 777)
+  #  6. Optionally, set the REPO2DOCKER_USERNAME to be where you want the
+  #     repo2docker REPO2DOCKERs and virtual environment to be installed
   #     (default is joyvan)
   setup:
     environment:
@@ -78,12 +78,12 @@ jobs:
                 then
                     DOCKER_TAG=$(echo "${CIRCLE_SHA1}" | cut -c1-10)
             fi
-            # If not set, define CONTAINER_NAME
-            if [ ! -n "${CONTAINER_NAME:-}" ]
+            # If not set, define IMAGE_NAME
+            if [ ! -n "${IMAGE_NAME:-}" ]
                 then
-                    CONTAINER_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+                    IMAGE_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
             fi
-            echo "Container name is ${CONTAINER_NAME}"
+            echo "Container name is ${IMAGE_NAME}"
             # If not set, define REPO_NAME
             if [ ! -n "${REPO_NAME:-}" ]
                 then
@@ -94,24 +94,24 @@ jobs:
             else
                 echo "Repository name found defined for build: ${REPO_NAME}"
             fi
-            # If not set, define NOTEBOOK_PERMISSION
-            if [ ! -n "${NOTEBOOK_PERMISSION:-}" ]
+            # If not set, define REPO2DOCKER_PERMISSION
+            if [ ! -n "${REPO2DOCKER_PERMISSION:-}" ]
                 then
-                    NOTEBOOK_PERMISSION=777;
+                    REPO2DOCKER_PERMISSION=777;
             fi
-            # If not set, define NOTEBOOK_USERNAME
-            if [ ! -n "${NOTEBOOK_USERNAME:-}" ]
+            # If not set, define REPO2DOCKER_USERNAME
+            if [ ! -n "${REPO2DOCKER_USERNAME:-}" ]
                 then
-                    NOTEBOOK_USERNAME=joyvan;
+                    REPO2DOCKER_USERNAME=joyvan;
             fi
             echo "2. Running jupyter-repo2docker..."
-            echo "jupyter-repo2docker --debug --user-name ${NOTEBOOK_USERNAME} --user-id 1000 --no-run --image-name ${CONTAINER_NAME}:${DOCKER_TAG} ${REPO_NAME}"
-            jupyter-repo2docker --debug --user-name ${NOTEBOOK_USERNAME} --user-id 1000 --no-run --image-name "${CONTAINER_NAME}:${DOCKER_TAG}" "${REPO_NAME}"
-            # Issue command to make /home/${NOTEBOOK_USERNAME} read/write for any user, to support Singularity
-            echo "Changing permissions to chmod -R ${NOTEBOOK_PERMISSION} /home/${NOTEBOOK_USERNAME}"
-            docker run --name repo2docker -td "${CONTAINER_NAME}:${DOCKER_TAG}"
-            docker exec repo2docker chmod -R ${NOTEBOOK_PERMISSION} "/home/${NOTEBOOK_USERNAME}"
-            docker commit repo2docker "${CONTAINER_NAME}:${DOCKER_TAG}"
+            echo "jupyter-repo2docker --debug --user-name ${REPO2DOCKER_USERNAME} --user-id 1000 --no-run --image-name ${IMAGE_NAME}:${DOCKER_TAG} ${REPO_NAME}"
+            jupyter-repo2docker --debug --user-name ${REPO2DOCKER_USERNAME} --user-id 1000 --no-run --image-name "${IMAGE_NAME}:${DOCKER_TAG}" "${REPO_NAME}"
+            # Issue command to make /home/${REPO2DOCKER_USERNAME} read/write for any user, to support Singularity
+            echo "Changing permissions to chmod -R ${REPO2DOCKER_PERMISSION} /home/${REPO2DOCKER_USERNAME}"
+            docker run --name repo2docker -td "${IMAGE_NAME}:${DOCKER_TAG}"
+            docker exec repo2docker chmod -R ${REPO2DOCKER_PERMISSION} "/home/${REPO2DOCKER_USERNAME}"
+            docker commit repo2docker "${IMAGE_NAME}:${DOCKER_TAG}"
             docker ps
             docker images
       - run:
@@ -123,14 +123,14 @@ jobs:
                 then
                     DOCKER_TAG=$(echo "${CIRCLE_SHA1}" | cut -c1-10)
             fi
-            # If not set, define CONTAINER_NAME
-            if [ ! -n "${CONTAINER_NAME:-}" ]
+            # If not set, define IMAGE_NAME
+            if [ ! -n "${IMAGE_NAME:-}" ]
                 then
-                    CONTAINER_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+                    IMAGE_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
             fi
-            echo "Saving ${CONTAINER_NAME}:${DOCKER_TAG} to container.tar.gz"
+            echo "Saving ${IMAGE_NAME}:${DOCKER_TAG} to container.tar.gz"
             mkdir -p /tmp/cache
-            docker save ${CONTAINER_NAME}:${DOCKER_TAG} \
+            docker save ${IMAGE_NAME}:${DOCKER_TAG} \
               | pigz -2 -p 3 > /tmp/cache/container.tar.gz
       - persist_to_workspace:
           root: /tmp
@@ -179,18 +179,18 @@ jobs:
                 then
                     DOCKER_TAG=$(echo "${CIRCLE_SHA1}" | cut -c1-10)
             fi
-            # If not set, define CONTAINER_NAME
-            if [[ ! -n "${CONTAINER_NAME:-}" ]]
+            # If not set, define IMAGE_NAME
+            if [[ ! -n "${IMAGE_NAME:-}" ]]
                 then
-                    CONTAINER_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+                    IMAGE_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
             fi
-            echo "Container name set to ${CONTAINER_NAME}:${DOCKER_TAG}"
+            echo "Container name set to ${IMAGE_NAME}:${DOCKER_TAG}"
             if [[ -n "$DOCKER_PASS" ]]; then
                   docker login -u $DOCKER_USER -p $DOCKER_PASS
-                  docker push ${CONTAINER_NAME}:${DOCKER_TAG}
+                  docker push ${IMAGE_NAME}:${DOCKER_TAG}
                   echo "Tagging latest image..."
-                  docker tag ${CONTAINER_NAME}:${DOCKER_TAG} ${CONTAINER_NAME}:latest
-                  docker push ${CONTAINER_NAME}:latest
+                  docker tag ${IMAGE_NAME}:${DOCKER_TAG} ${IMAGE_NAME}:latest
+                  docker push ${IMAGE_NAME}:latest
             fi
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,6 @@ jobs:
                     CONTAINER_NAME="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
             fi
             echo "Container name set to ${CONTAINER_NAME}:${DOCKER_TAG}"
-            echo "Container name set to ${CONTAINER_NAME}:${DOCKER_TAG}"
             if [[ -n "$DOCKER_PASS" ]]; then
                   docker login -u $DOCKER_USER -p $DOCKER_PASS
                   docker push ${CONTAINER_NAME}:${DOCKER_TAG}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .ipynb_checkpoints
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@ This is the continuous build repository, with example configurations (and a basi
 one set up to run on CircleCI) to show how you can use repo2docker to build
 a container that serves your notebook for others to use.
 
+ - [.circleci/config.yml](.circleci/config.yml) is a basic (default) configuration to build and deploy
+ - [.circleci/config.singularity.yml](.circleci/config.singularity.yml) is a slightly modified configuration that affords easy export to Singularity containers (allowing write to the notebooks on a shared resource).
+
+For details about the environment variables you can control for each of these templates, see the README.md in 
+the [.circleci](.circleci) folder.
+
 ## Documentation
 
 You will generally want to copy the `.circleci` folder and its contents to your own folder
-with some corresponding notebook and requirements file. For complete documentation, please see 
+with some corresponding notebook and requirements file, and ensure that the template
+you desire to use in the [.circleci](.circleci) folder is named `config.yml`. 
+For complete documentation, please see 
 [repo2docker](https://repo2docker.readthedocs.io/en/latest/deploy.html) 
 on ReadTheDocs.
 


### PR DESCRIPTION
This is a second effort to add Singularity support, to come after #9. Instead of having the permission change be default, we instead provide a second template, and give the user complete control over the username of the build (in the case that they want to generate a container for their userspace only) OR the value of the permissions to be different from the default. Specifically, this PR does the following:

 - **adds a .gitignore** for ipynb_checkpoints. I would assume that most users will do a `git add *` and then also include various files that wouldn't be desired, and this will help with that :)
 - **addition of the Singularity template** in the .circleci folder for Singularity containers. Instead of this being default, a user can just have the option to switch to a slightly modified configuration, if Singularity container use on a shared resource is desired. As we discussed in #9, the write happens by way of the overlayfs, so the user would be able to interact (write) using the notebooks provided by the container, but would need to save locally or to a different spot on the resource (I've tested this and it works ok!) My concern about security is mitigated - the save is happening via the overlayfs.
 - **README.md to describe variables** for each configuration, the user should be given a clear table that shows what variables are available to customize the build (we thus far were doing this in comments in the configuration file.) You can read the [rendered version](https://github.com/vsoch/continuous-build/tree/support/singularity/.circleci) here.
 - **Addition of pushing latest** I probably should have done this in a separate PR (bad dinosaur!) but I think it's a small enough (and useful) addition to both recipes that the "latest" image is also pushed. That said, if there is huge opposition I can remove it from here for another PR / more discussion. This will close #14 

